### PR TITLE
fix: prevent duplicate plan property IDs on demo upload

### DIFF
--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -103,6 +103,8 @@ demoRouter.post('/', auth, async (req: any, res) => {
                 ...pp,
                 project: demoModel._id
             };
+            delete (ppData as any)._id;
+            
             const newPP = new PlanPropertyModel(ppData);
             await newPP.save();
         }
@@ -521,16 +523,21 @@ demoRouter.post('/upload', auth, async (req: any, res) => {
 
         for (const pp of planPropertiesData) {
 
-            let ppData: PlanPropertyOfProject = pp;
             const old_id = pp._id;
-            ppData.project = demoModel._id;
-            const newPP = new PlanPropertyModel(ppData);
-            const newProperty = await newPP.save();
-
+            
             if(old_id == undefined){
                 res.status(403);
                 return;
             }
+
+            let ppData: PlanPropertyOfProject = {
+                ...pp,
+                project: demoModel._id
+            };
+            delete (ppData as any)._id;
+            
+            const newPP = new PlanPropertyModel(ppData);
+            const newProperty = await newPP.save();
 
             planPropertyIdMapping[old_id] = newProperty._id;
         }


### PR DESCRIPTION
@r-eifler this is because I encountered a bug while uploading twice the same demo : 

The ids of the plan property were attempted to be saved from the demo file

```
GET /api/demo/ 200 10.816 ms - 127191
#properties: 16
GET /api/plan-property/?projectId=68e62a5b58f8ef0163d5bb2f 200 6.021 ms - 7269
#properties: 0
GET /api/plan-property/?projectId=68e630d3e7fea0b361f48587 200 3.960 ms - 2
MongoServerError: E11000 duplicate key error collection: ipexco.plan-properties index: _id_ dup key: { _id: ObjectId('68d677bd7cf326d596c2dc2e') }
    at InsertOneOperation.execute (/usr/src/app/node_modules/mongodb/lib/operations/insert.js:51:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async tryOperation (/usr/src/app/node_modules/mongodb/lib/operations/execute_operation.js:207:20)
    at async executeOperation (/usr/src/app/node_modules/mongodb/lib/operations/execute_operation.js:75:16)
    at async Collection.insertOne (/usr/src/app/node_modules/mongodb/lib/collection.js:157:16) {
  errorLabelSet: Set(0) {},
  errorResponse: {
    index: 0,
    code: 11000,
    errmsg: "E11000 duplicate key error collection: ipexco.plan-properties index: _id_ dup key: { _id: ObjectId('68d677bd7cf326d596c2dc2e') }",
    keyPattern: { _id: 1 },
    keyValue: { _id: new ObjectId('68d677bd7cf326d596c2dc2e') }
  },
  index: 0,
  code: 11000,
  keyPattern: { _id: 1 },
  keyValue: { _id: new ObjectId('68d677bd7cf326d596c2dc2e') }
}
POST /api/demo/upload - - ms - -
GET /api/users/ 304 2.410 ms - -
```

I let mongodb generate a new id for each upload instead. 